### PR TITLE
Link added in docs to my FFT sentiment analysis repo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,3 +18,7 @@ The documentation is split into three separate sections:
     - [Factories](reference/pxtextmining/factories/factory_data_load_and_split.md)
     - [Helpers](reference/pxtextmining/helpers/text_preprocessor.md)
     - [Pipelines](reference/pxtextmining/pipelines/multilabel_pipeline.md)
+
+### Other repos that use `pxtextmining`
+ - [nhs_fft_sentiment_analysis](https://github.com/yunus-m/nhs_fft_sentiment_analysis/blob/main/README.md)
+   - Exploratory analysis and sentiment modelling of FFT feedback using `scikit-learn`, TinyBERT, and hierarchical approaches.


### PR DESCRIPTION
# Description

On the docs landing page, I have linked to my FFT sentiment analysis repo under a new section entitled "Other repos that use pxtextmining".

## Type of change

This change amends the documentation landing page.

## Testing

I have previewed the modified `index.md` and confirmed the newly-added URL and layout to be as expected.

# Checklist
- [ x ] My documentation change respects the existing layout and formatting. You are welcome to suggest modifications.